### PR TITLE
texture_cache/surface_params: Force depth=1 on 2D textures

### DIFF
--- a/src/video_core/texture_cache/surface_params.cpp
+++ b/src/video_core/texture_cache/surface_params.cpp
@@ -113,8 +113,10 @@ SurfaceParams SurfaceParams::CreateForTexture(const FormatLookupTable& lookup_ta
         params.height = tic.Height();
         params.depth = tic.Depth();
         params.pitch = params.is_tiled ? 0 : tic.Pitch();
-        if (params.target == SurfaceTarget::TextureCubemap ||
-            params.target == SurfaceTarget::TextureCubeArray) {
+        if (params.target == SurfaceTarget::Texture2D && params.depth > 1) {
+            params.depth = 1;
+        } else if (params.target == SurfaceTarget::TextureCubemap ||
+                   params.target == SurfaceTarget::TextureCubeArray) {
             params.depth *= 6;
         }
         params.num_levels = tic.max_mip_level + 1;


### PR DESCRIPTION
Sometimes games will sample a 2D array TIC with a 2D access in the
shader. This causes bad interactions with the rest of the texture cache.
To emulate what the game wants to do, force a depth=1 on 2D textures
(not 2D arrays) and let the texture cache handle the rest.