### PR TITLE
PageTable: move backing addresses to a children class as the CPU page…

### DIFF
--- a/src/common/page_table.cpp
+++ b/src/common/page_table.cpp
@@ -16,7 +16,6 @@ void PageTable::Resize(std::size_t address_space_width_in_bits) {
 
     pointers.resize(num_page_table_entries);
     attributes.resize(num_page_table_entries);
-    backing_addr.resize(num_page_table_entries);
 
     // The default is a 39-bit address space, which causes an initial 1GB allocation size. If the
     // vector size is subsequently decreased (via resize), the vector might not automatically
@@ -25,6 +24,17 @@ void PageTable::Resize(std::size_t address_space_width_in_bits) {
 
     pointers.shrink_to_fit();
     attributes.shrink_to_fit();
+}
+
+BackingPageTable::BackingPageTable(std::size_t page_size_in_bits) : PageTable{page_size_in_bits} {}
+
+BackingPageTable::~BackingPageTable() = default;
+
+void BackingPageTable::Resize(std::size_t address_space_width_in_bits) {
+    PageTable::Resize(address_space_width_in_bits);
+    const std::size_t num_page_table_entries = 1ULL
+                                               << (address_space_width_in_bits - page_size_in_bits);
+    backing_addr.resize(num_page_table_entries);
     backing_addr.shrink_to_fit();
 }
 

--- a/src/common/page_table.h
+++ b/src/common/page_table.h
@@ -76,9 +76,20 @@ struct PageTable {
      */
     std::vector<PageType> attributes;
 
-    std::vector<u64> backing_addr;
-
     const std::size_t page_size_in_bits{};
+};
+
+/**
+ * A more advanced Page Table with the ability to save a backing address when using it
+ * depends on another MMU.
+ */
+struct BackingPageTable : PageTable {
+    explicit BackingPageTable(std::size_t page_size_in_bits);
+    ~BackingPageTable();
+
+    void Resize(std::size_t address_space_width_in_bits);
+
+    std::vector<u64> backing_addr;
 };
 
 } // namespace Common

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -174,7 +174,7 @@ private:
     /// End of address space, based on address space in bits.
     static constexpr GPUVAddr address_space_end{1ULL << address_space_width};
 
-    Common::PageTable page_table{page_bits};
+    Common::BackingPageTable page_table{page_bits};
     VMAMap vma_map;
     VideoCore::RasterizerInterface& rasterizer;
 


### PR DESCRIPTION
… table does not need them.

This PR aims to reduce the memory usage in the CPU page table by moving
GPU specific parameters into a child class. This saves 1Gb of Memory for
most games.